### PR TITLE
Fix chat send and add VS Code launch configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Run GoGuesser",
+            "program": "${workspaceFolder}/app.js"
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "app.js",
   "scripts": {
+    "start": "node app.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/public/main.js
+++ b/public/main.js
@@ -1,5 +1,7 @@
+let socket;
+
 document.addEventListener('DOMContentLoaded', () => {
-    const socket = io();
+    socket = io();
     let currentPlayer = null;
     let userVote = null;
     
@@ -33,7 +35,9 @@ document.addEventListener('DOMContentLoaded', () => {
     function disableBoardInteractions() {
         if(currentPlayer && currentPlayer.board) {
             currentPlayer.board.element.style.pointerEvents = 'none';
-            currentPlayer.board._eventListeners.click = [];
+            if(currentPlayer.board._eventListeners && currentPlayer.board._eventListeners.click) {
+                currentPlayer.board._eventListeners.click = [];
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- fix `sendMessage` by exposing socket
- guard against undefined board listeners when disabling interactions
- add `start` script for npm
- add VS Code `launch.json` for running without debugging

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_687368454098832bb55731f96051351f