### PR TITLE
Display user ranks in chat

### DIFF
--- a/app.js
+++ b/app.js
@@ -138,10 +138,13 @@ io.on('connection', (socket) => {
     }
     
     // Handle chat messages
-    socket.on('chat-message', (message) => {
-        const clean = sanitizeHtml(message, { allowedTags: [], allowedAttributes: {} });
+    socket.on('chat-message', (data) => {
+        const text = typeof data === 'string' ? data : data.text;
+        const rank = data && data.rank ? data.rank : '?';
+        const clean = sanitizeHtml(text, { allowedTags: [], allowedAttributes: {} });
         io.emit('chat-message', {
             text: clean,
+            rank,
             timestamp: new Date().toISOString(),
             user: username
         });

--- a/public/main.js
+++ b/public/main.js
@@ -85,7 +85,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const userSpan = document.createElement('span');
         userSpan.className = 'user';
-        userSpan.textContent = `[${msg.user}]`;
+        const rankText = msg.rank ? msg.rank : '?';
+        userSpan.textContent = `${msg.user} (${rankText})`;
 
         const textNode = document.createTextNode(` ${msg.text} `);
 
@@ -121,7 +122,8 @@ document.addEventListener('DOMContentLoaded', () => {
 function sendMessage() {
     const message = document.getElementById('chat-input').value.trim();
     if(message) {
-        socket.emit('chat-message', message);
+        const rank = localStorage.getItem('local_rank') || '?';
+        socket.emit('chat-message', { text: message, rank });
         document.getElementById('chat-input').value = '';
     }
 }


### PR DESCRIPTION
## Summary
- remove unused rank input from the login page
- show stored rank with each chat username
- include the local rank when sending a chat message
- handle incoming rank on the server

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687405ae305c832b9d3d343745828f68