### PR TITLE
Implement username persistence

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -13,5 +13,21 @@
         <input type="text" name="username" placeholder="Enter your name" required>
         <button type="submit">Join</button>
     </form>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const form = document.querySelector('form');
+            const input = form.querySelector('input[name="username"]');
+            const savedName = localStorage.getItem('username');
+
+            if (savedName) {
+                input.value = savedName;
+                form.submit();
+            }
+
+            form.addEventListener('submit', () => {
+                localStorage.setItem('username', input.value.trim());
+            });
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- save name to `localStorage` when logging in
- auto submit login form if a stored name exists

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68740979d4f0832badf0ca556853d1ac