### PR TITLE
Enable rank from URL

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -15,6 +15,12 @@
     </form>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
+            const params = new URLSearchParams(window.location.search);
+            const urlRank = params.get('rank');
+            if (urlRank) {
+                localStorage.setItem('local_rank', urlRank);
+            }
+
             const form = document.querySelector('form');
             const input = form.querySelector('input[name="username"]');
             const savedName = localStorage.getItem('username');

--- a/public/main.js
+++ b/public/main.js
@@ -1,6 +1,12 @@
 let socket;
 
 document.addEventListener('DOMContentLoaded', () => {
+    const params = new URLSearchParams(window.location.search);
+    const urlRank = params.get('rank');
+    if (urlRank) {
+        localStorage.setItem('local_rank', urlRank);
+    }
+
     socket = io();
     let currentPlayer = null;
     let userVote = null;


### PR DESCRIPTION
## Summary
- set `local_rank` from `rank` query parameter on login and main pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68740d2ff90c832bb3d7912d8c973912