### PR TITLE
Add answer reveal and flash effect

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -113,6 +113,15 @@ document.addEventListener('DOMContentLoaded', () => {
         timeLeft.textContent = time;
     });
 
+    socket.on('answer', (correct) => {
+        const original = document.body.style.backgroundColor;
+        const isCorrect = userVote && userVote === correct;
+        document.body.style.backgroundColor = isCorrect ? '#8BC34A' : '#F44336';
+        setTimeout(() => {
+            document.body.style.backgroundColor = original || '';
+        }, 500);
+    });
+
     // Event listeners
     document.querySelectorAll('.vote-button').forEach(button => {
         button.addEventListener('click', (e) => {

--- a/server/sgf.js
+++ b/server/sgf.js
@@ -23,6 +23,11 @@ function findPuzzleMove(content) {
     return 0;
 }
 
+function findAnswer(content) {
+    const match = content.match(/Answer:([ABC])/);
+    return match ? match[1] : null;
+}
+
 function getRandomSGF() {
     const files = getSGFFiles();
     if (!files.length) return null;
@@ -31,7 +36,8 @@ function getRandomSGF() {
     return {
         name: randomFile.name.split('_')[0],
         move: findPuzzleMove(sgfContent),
-        content: sgfContent
+        content: sgfContent,
+        answer: findAnswer(sgfContent)
     };
 }
 

--- a/server/socketHandlers.js
+++ b/server/socketHandlers.js
@@ -35,8 +35,17 @@ function initSocket(io, sessionMiddleware) {
             timer--;
             io.emit('time-update', timer);
             if (timer <= 0) {
-                timer = SGF_INTERVAL;
-                sendNewSGF();
+                io.emit('answer', currentSGF ? currentSGF.answer : null);
+                io.emit('chat-message', {
+                    text: `The correct answer was: ${currentSGF ? currentSGF.answer : '?'}`,
+                    rank: '',
+                    timestamp: new Date().toISOString(),
+                    user: 'System'
+                });
+                setTimeout(() => {
+                    timer = SGF_INTERVAL;
+                    sendNewSGF();
+                }, 1000);
             }
         }, 1000);
     }


### PR DESCRIPTION
## Summary
- parse correct answer from SGF files
- broadcast the answer at timer expiry and post a chat message
- flash page background based on user's vote

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68741510fa54832bb5fb7d032b9254cc