### PR TITLE
Enable session cookie for cross‑site iframes

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,7 +13,11 @@ const io = new Server(server);
 const sessionMiddleware = session({
     secret: 'change-this-secret',
     resave: false,
-    saveUninitialized: false
+    saveUninitialized: false,
+    cookie: {
+        sameSite: 'none',
+        secure: true
+    }
 });
 
 app.use(express.urlencoded({ extended: false }));


### PR DESCRIPTION
## Summary
- allow GoGuesser to operate in an iframe by setting `SameSite=None; Secure` on its session cookie

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68742c32c7f4832bb4f627f003c67a69