### PR TITLE
Ensure new puzzle differs from last

### DIFF
--- a/server/sgf.js
+++ b/server/sgf.js
@@ -28,10 +28,21 @@ function findAnswer(content) {
     return match ? match[1] : null;
 }
 
-function getRandomSGF() {
+function getRandomSGF(excludeName = null) {
     const files = getSGFFiles();
     if (!files.length) return null;
-    const randomFile = files[Math.floor(Math.random() * files.length)];
+
+    let randomFile = files[Math.floor(Math.random() * files.length)];
+
+    // Try to avoid returning the same file consecutively when possible
+    if (excludeName && files.length > 1) {
+        let attempts = 0;
+        while (randomFile.name === excludeName && attempts < 10) {
+            randomFile = files[Math.floor(Math.random() * files.length)];
+            attempts++;
+        }
+    }
+
     const sgfContent = fs.readFileSync(randomFile.path, 'utf8');
     return {
         name: randomFile.name.split('_')[0],

--- a/server/socketHandlers.js
+++ b/server/socketHandlers.js
@@ -16,12 +16,14 @@ function initSocket(io, sessionMiddleware) {
 
     let timer = SGF_INTERVAL;
     let currentSGF = null;
+    let lastSGFName = null;
     let voteCounts = { A: 0, B: 0, C: 0 };
 
     function sendNewSGF() {
-        const sgf = getRandomSGF();
+        const sgf = getRandomSGF(lastSGFName);
         if (!sgf) return;
         currentSGF = sgf;
+        lastSGFName = sgf.name;
         voteCounts = { A: 0, B: 0, C: 0 };
         io.emit('sgf-data', {
             ...currentSGF,


### PR DESCRIPTION
## Summary
- avoid consecutive repeat of the same SGF puzzle by tracking the last file served
- expose a parameter for `getRandomSGF` to accept a file name to exclude

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687436dcc860832b9a7c2d65355274de