### PR TITLE
Add delay before next puzzle

### DIFF
--- a/server/socketHandlers.js
+++ b/server/socketHandlers.js
@@ -47,7 +47,7 @@ function initSocket(io, sessionMiddleware) {
                 setTimeout(() => {
                     timer = SGF_INTERVAL;
                     sendNewSGF();
-                }, 1000);
+                }, 10000);
             }
         }, 1000);
     }


### PR DESCRIPTION
## Summary
- insert a 10-second break after revealing the answer

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68743765286c832babdf213f4eec8c95