### PR TITLE
Implement message rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a small Node.js app for reviewing Go problems with real-time voting and chat.
 
+Messages in the chat are rate limited to **one per second** per user.
+
 Vote counts are broadcast every 100 ms so the A/B/C buttons update
 continuously without needing to press an update button.
 

--- a/server/socketHandlers.js
+++ b/server/socketHandlers.js
@@ -69,6 +69,12 @@ function initSocket(io, sessionMiddleware) {
         }
 
         socket.on('chat-message', data => {
+            const now = Date.now();
+            if (socket.lastMessageTime && now - socket.lastMessageTime < 1000) {
+                return; // limit to 1 message per second
+            }
+            socket.lastMessageTime = now;
+
             const text = typeof data === 'string' ? data : data.text;
             const rank = data && data.rank ? data.rank : '?';
             const clean = sanitizeHtml(text, { allowedTags: [], allowedAttributes: {} });


### PR DESCRIPTION
## Summary
- enforce 1 second delay between user messages
- document chat rate limit in README

## Testing
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_68743b503b50832ba2dedae57a02d00a