### PR TITLE
Add basic server-side swear filter

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -1,3 +1,3 @@
-- swear filter
+- ~~swear filter~~
 - auto login
 - score

--- a/server/socketHandlers.js
+++ b/server/socketHandlers.js
@@ -1,4 +1,5 @@
 const sanitizeHtml = require('sanitize-html');
+const filterSwears = require('./swearFilter');
 const { SGF_INTERVAL } = require('./config');
 const { getRandomSGF } = require('./sgf');
 
@@ -84,8 +85,9 @@ function initSocket(io, sessionMiddleware) {
             const text = typeof data === 'string' ? data : data.text;
             const rank = data && data.rank ? data.rank : '?';
             const clean = sanitizeHtml(text, { allowedTags: [], allowedAttributes: {} });
+            const filtered = filterSwears(clean);
             io.emit('chat-message', {
-                text: clean,
+                text: filtered,
                 rank,
                 timestamp: new Date().toISOString(),
                 user: username

--- a/server/swearFilter.js
+++ b/server/swearFilter.js
@@ -1,0 +1,15 @@
+const bannedWords = [
+    'fuck',
+    'shit',
+    'damn',
+    'crap',
+    'bitch',
+    'asshole'
+];
+
+function filterSwears(text) {
+    const regex = new RegExp(`\\b(${bannedWords.join('|')})\\b`, 'gi');
+    return text.replace(regex, match => '*'.repeat(match.length));
+}
+
+module.exports = filterSwears;


### PR DESCRIPTION
## Summary
- filter out common swear words from chat
- include new swearFilter module
- mark swear filter as done in notes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874a9282e90832b8ecb262f9a54c920