### PR TITLE
Update swear filter to use profane-words list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "express": "^4.21.2",
         "express-session": "^1.18.1",
+        "profane-words": "^1.6.0",
         "sanitize-html": "^2.17.0",
         "socket.io": "^4.8.1"
       }
@@ -837,6 +838,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/profane-words": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/profane-words/-/profane-words-1.6.0.tgz",
+      "integrity": "sha512-BJa9m5yfTCjV+m7KxqGlK49lugCnpbEQ9MJkp/SCpVwKWq4Wiw5G0EaWcQgzY5xPtheRmM1MjF95/uqGV3oQlQ==",
+      "license": "WTFPL"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -1815,6 +1822,11 @@
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       }
+    },
+    "profane-words": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/profane-words/-/profane-words-1.6.0.tgz",
+      "integrity": "sha512-BJa9m5yfTCjV+m7KxqGlK49lugCnpbEQ9MJkp/SCpVwKWq4Wiw5G0EaWcQgzY5xPtheRmM1MjF95/uqGV3oQlQ=="
     },
     "proxy-addr": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "express": "^4.21.2",
     "express-session": "^1.18.1",
+    "profane-words": "^1.6.0",
     "sanitize-html": "^2.17.0",
     "socket.io": "^4.8.1"
   }

--- a/server/swearFilter.js
+++ b/server/swearFilter.js
@@ -1,14 +1,12 @@
-const bannedWords = [
-    'fuck',
-    'shit',
-    'damn',
-    'crap',
-    'bitch',
-    'asshole'
-];
+const bannedWords = require('profane-words');
+
+function escapeRegex(word) {
+    return word.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&');
+}
+
+const regex = new RegExp(`(?:${bannedWords.map(escapeRegex).join('|')})`, 'gi');
 
 function filterSwears(text) {
-    const regex = new RegExp(`\\b(${bannedWords.join('|')})\\b`, 'gi');
     return text.replace(regex, match => '*'.repeat(match.length));
 }
 


### PR DESCRIPTION
## Summary
- add `profane-words` dependency
- switch swear filtering to use profane-words dataset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874aa31b40c832ba2af0dc616876760