### PR TITLE
Enforce 256 character limit on chat messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a small Node.js app for playing through Go problems with real-time voting and chat.
 
-Messages in the chat are rate limited to **one per second** per user.
+Messages in the chat are rate limited to **one per second** per user. Each message can contain at most **256 characters**.
 
 Vote counts are broadcast every 100 ms so the A/B/C buttons update
 continuously without needing to press an update button.

--- a/public/main.js
+++ b/public/main.js
@@ -165,11 +165,16 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 function sendMessage() {
-    const message = document.getElementById('chat-input').value.trim();
+    const input = document.getElementById('chat-input');
+    let message = input.value.trim();
+    const MAX_LENGTH = 256;
+    if (message.length > MAX_LENGTH) {
+        message = message.slice(0, MAX_LENGTH);
+    }
     if(message) {
         const rank = localStorage.getItem('local_rank') || '?';
         socket.emit('chat-message', { text: message, rank });
-        document.getElementById('chat-input').value = '';
+        input.value = '';
     }
 }
 

--- a/server/socketHandlers.js
+++ b/server/socketHandlers.js
@@ -89,9 +89,19 @@ function initSocket(io, sessionMiddleware) {
             }
             socket.lastMessageTime = now;
 
-            const text = typeof data === 'string' ? data : data.text;
+            const MAX_LENGTH = 256;
+            let text = typeof data === 'string' ? data : data.text;
             const rank = data && data.rank ? data.rank : '?';
-            const clean = sanitizeHtml(text, { allowedTags: [], allowedAttributes: {} });
+
+            if (text.length > MAX_LENGTH) {
+                text = text.slice(0, MAX_LENGTH);
+            }
+
+            let clean = sanitizeHtml(text, { allowedTags: [], allowedAttributes: {} });
+            if (clean.length > MAX_LENGTH) {
+                clean = clean.slice(0, MAX_LENGTH);
+            }
+
             const filtered = filterSwears(clean);
             io.emit('chat-message', {
                 text: filtered,


### PR DESCRIPTION
## Summary
- enforce a 256 character limit in client-side `sendMessage`
- trim chat messages server-side in `socketHandlers`
- document the new message size limit in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874bdc43a28832b9d4c4f7d1c5d6611