### PR TITLE
Prevent repeating SGF puzzles

### DIFF
--- a/server/sgf.js
+++ b/server/sgf.js
@@ -28,20 +28,29 @@ function findAnswer(content) {
     return match ? match[1] : null;
 }
 
-function getRandomSGF(excludeName = null) {
-    const files = getSGFFiles();
-    if (!files.length) return null;
+// Keep a shuffled list of SGF files to ensure each puzzle is used once
+let remainingSGFs = [];
 
-    let randomFile = files[Math.floor(Math.random() * files.length)];
-
-    // Try to avoid returning the same file consecutively when possible
-    if (excludeName && files.length > 1) {
-        let attempts = 0;
-        while (randomFile.name === excludeName && attempts < 10) {
-            randomFile = files[Math.floor(Math.random() * files.length)];
-            attempts++;
-        }
+function shuffle(array) {
+    for (let i = array.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [array[i], array[j]] = [array[j], array[i]];
     }
+    return array;
+}
+
+function repopulateSGFs() {
+    remainingSGFs = shuffle(getSGFFiles());
+}
+
+function getRandomSGF() {
+    if (remainingSGFs.length === 0) {
+        repopulateSGFs();
+    }
+
+    if (remainingSGFs.length === 0) return null;
+
+    const randomFile = remainingSGFs.pop();
 
     const sgfContent = fs.readFileSync(randomFile.path, 'utf8');
     return {

--- a/server/socketHandlers.js
+++ b/server/socketHandlers.js
@@ -18,14 +18,12 @@ function initSocket(io, sessionMiddleware) {
     let timer = SGF_INTERVAL;
     let waiting = false;
     let currentSGF = null;
-    let lastSGFName = null;
     let voteCounts = { A: 0, B: 0, C: 0 };
 
     function sendNewSGF() {
-        const sgf = getRandomSGF(lastSGFName);
+        const sgf = getRandomSGF();
         if (!sgf) return;
         currentSGF = sgf;
-        lastSGFName = sgf.name;
         waiting = false;
         timer = SGF_INTERVAL;
         voteCounts = { A: 0, B: 0, C: 0 };


### PR DESCRIPTION
## Summary
- keep a shuffled list of SGF files so that each puzzle is used once before any are repeated
- update socket handler to use the new `getRandomSGF()` implementation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882ec55b974832bba982e9f01f2d29d