### PR TITLE
Implement game score tracking with localStorage

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -148,6 +148,13 @@
             margin-top: 10px;
         }
 
+        #score-display {
+            text-align: center;
+            font-size: 1em;
+            margin-top: 10px;
+            color: #333;
+        }
+
         .wgo-controls, .wgo-player-info {
             display: none !important;
         }
@@ -217,6 +224,7 @@
                     </div>
                 </div>
                 <div id="timer"><span id="timer-label">Round ends in</span>: <span id="time-left">30</span>s</div>
+                <div id="score-display">Score: <span id="game-score">0</span></div>
             </div>
         </div>
         <div id="answer-overlay"><span id="answer-text"></span></div>

--- a/public/main.js
+++ b/public/main.js
@@ -21,6 +21,20 @@ document.addEventListener('DOMContentLoaded', () => {
         B: document.getElementById('count-b'),
         C: document.getElementById('count-c')
     };
+    const scoreDisplay = document.getElementById('game-score');
+
+    function getGameScore() {
+        const val = parseInt(localStorage.getItem('game_score'), 10);
+        return isNaN(val) ? 0 : val;
+    }
+
+    function setGameScore(val) {
+        const normalized = Math.max(0, parseInt(val, 10) || 0);
+        localStorage.setItem('game_score', normalized);
+        if (scoreDisplay) scoreDisplay.textContent = normalized;
+    }
+
+    setGameScore(getGameScore());
 
     // Voting system
     function handleVote(option) {
@@ -130,6 +144,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     socket.on('answer', (correct) => {
         const isCorrect = userVote && userVote === correct;
+        if (isCorrect) {
+            setGameScore(getGameScore() + 1);
+        } else {
+            setGameScore(getGameScore() - 1);
+        }
         answerText.textContent = '';
         answerOverlay.classList.remove('flash-correct', 'flash-wrong');
         answerOverlay.classList.add(isCorrect ? 'flash-correct' : 'flash-wrong');


### PR DESCRIPTION
## Summary
- add score display in UI
- track `game_score` in localStorage with getter and setter
- update score on each answer based on correctness

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882ed21ffd8832b9b30db2c0c93efec