### PR TITLE
Keep answer highlight until next round

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -62,6 +62,12 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    function clearVoteButtons() {
+        document.querySelectorAll('.vote-button').forEach(btn => {
+            btn.classList.remove('selected', 'correct-answer');
+        });
+    }
+
     // SGF updates
     socket.on('sgf-data', (data) => {
         // Clear previous board
@@ -89,7 +95,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // Disable board interactions
         disableBoardInteractions();
         userVote = null;
-        document.querySelectorAll('.vote-button').forEach(btn => btn.classList.remove('selected'));
+        clearVoteButtons();
 
         // Update timer display based on round state
         if(data && typeof data.timer !== 'undefined') {
@@ -165,7 +171,6 @@ document.addEventListener('DOMContentLoaded', () => {
         setTimeout(() => {
             answerOverlay.style.display = 'none';
             answerOverlay.classList.remove('flash-correct', 'flash-wrong');
-            document.querySelectorAll('.vote-button').forEach(btn => btn.classList.remove('correct-answer'));
         }, 1000);
     });
 


### PR DESCRIPTION
## Summary
- keep button highlight between rounds via clearVoteButtons helper
- ensure clearing when new puzzle loads

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6882ef62283c832bb1ffccbdd147d34d