### PR TITLE
Improve mobile layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <title>Go Review</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="/socket.io/socket.io.js"></script>
     <script src="wgo/wgo.min.js"></script>
     <script src="wgo/wgo.player.min.js"></script>
@@ -96,7 +97,7 @@
 
         #chat-container {
             width: 300px;
-            display: flex;
+            display: none;
             flex-direction: column;
             background: white;
             border-radius: 8px;
@@ -195,11 +196,57 @@
             background: #8BC34A;
             color: #fff;
         }
+
+        @media (max-width: 600px) {
+            body {
+                flex-direction: column;
+                padding: 10px;
+                height: auto;
+            }
+
+            #main-container {
+                flex-direction: column;
+                align-items: center;
+                gap: 10px;
+            }
+
+            #game-section {
+                flex-direction: column;
+                align-items: center;
+            }
+
+            #board-container {
+                width: 90vmin;
+                height: 90vmin;
+                min-width: 0;
+            }
+
+            #vote-container {
+                width: 100%;
+                justify-content: space-around;
+            }
+
+            #chat-container {
+                width: 100%;
+                max-height: 50vh;
+                position: fixed;
+                bottom: 0;
+                left: 0;
+                right: 0;
+                z-index: 1000;
+            }
+
+            #chat-toggle {
+                top: auto;
+                bottom: 10px;
+                left: 10px;
+            }
+        }
     </style>
 </head>
 <body>
     <button id="exit-button" onclick="exitApp()">Exit</button>
-    <button id="chat-toggle">Hide Chat</button>
+    <button id="chat-toggle">Open Chat</button>
     <div id="main-container">
         <div id="chat-container">
             <div id="chat-messages"></div>

--- a/public/index.html
+++ b/public/index.html
@@ -114,6 +114,20 @@
             border-radius: 4px;
         }
 
+        #chat-controls {
+            display: flex;
+            gap: 10px;
+            align-items: center;
+        }
+
+        #chat-close {
+            padding: 5px 10px;
+        }
+
+        #chat-send {
+            padding: 5px 10px;
+        }
+
         .message {
             margin-bottom: 10px;
             padding: 8px;
@@ -135,11 +149,10 @@
         }
 
         #chat-input {
-            width: 100%;
+            flex: 1;
             padding: 10px;
             border: 1px solid #ddd;
             border-radius: 4px;
-            margin-bottom: 10px;
         }
 
         #timer {
@@ -250,8 +263,11 @@
     <div id="main-container">
         <div id="chat-container">
             <div id="chat-messages"></div>
-            <input type="text" id="chat-input" placeholder="Type your message...">
-            <button onclick="sendMessage()">Send</button>
+            <div id="chat-controls">
+                <button id="chat-close" onclick="toggleChat()">Close</button>
+                <input type="text" id="chat-input" placeholder="Type your message...">
+                <button id="chat-send" onclick="sendMessage()">Send</button>
+            </div>
         </div>
         <div id="game-section">
             <div id="board-container"></div>

--- a/public/main.js
+++ b/public/main.js
@@ -211,9 +211,10 @@ function toggleChat() {
     const btn = document.getElementById('chat-toggle');
     if (chat.style.display === 'none' || chat.style.display === '') {
         chat.style.display = 'flex';
-        btn.textContent = 'Close Chat';
+        btn.style.display = 'none';
+        document.getElementById('chat-input').focus();
     } else {
         chat.style.display = 'none';
-        btn.textContent = 'Open Chat';
+        btn.style.display = 'block';
     }
 }

--- a/public/main.js
+++ b/public/main.js
@@ -209,11 +209,11 @@ function exitApp() {
 function toggleChat() {
     const chat = document.getElementById('chat-container');
     const btn = document.getElementById('chat-toggle');
-    if (chat.style.display === 'none') {
+    if (chat.style.display === 'none' || chat.style.display === '') {
         chat.style.display = 'flex';
-        btn.textContent = 'Hide Chat';
+        btn.textContent = 'Close Chat';
     } else {
         chat.style.display = 'none';
-        btn.textContent = 'Show Chat';
+        btn.textContent = 'Open Chat';
     }
 }


### PR DESCRIPTION
## Summary
- add viewport meta tag
- hide chat initially and provide open/close button
- add responsive layout CSS so board stacks above vote buttons on mobile
- adjust chat toggle text and function

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68855fe49584832b96febde5458b0f92