### PR TITLE
fix: align chat controls within container

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -103,6 +103,7 @@
             border-radius: 8px;
             padding: 20px;
             box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            box-sizing: border-box;
         }
 
         #chat-messages {
@@ -118,6 +119,7 @@
             display: flex;
             gap: 10px;
             align-items: center;
+            width: 100%;
         }
 
         #chat-close {
@@ -150,6 +152,7 @@
 
         #chat-input {
             flex: 1;
+            min-width: 0;
             padding: 10px;
             border: 1px solid #ddd;
             border-radius: 4px;


### PR DESCRIPTION
## Summary
- Prevent chat controls from overflowing by making the container box-sizing border-box
- Ensure chat input and controls resize properly within the chat container

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689149404784832b8d1ee5f18b4fdc98